### PR TITLE
クラス名と変数名は別物にした方がいいかも知れません

### DIFF
--- a/ViewController.swift
+++ b/ViewController.swift
@@ -58,6 +58,9 @@ class ViewController: UIViewController {
 
         //カスタマイズViewを追加
         self.view.addSubview(myView)
+        
+        // メンバ変数に代入する
+        self.timerView = myView
     }
     
     override func didReceiveMemoryWarning() {

--- a/ViewController.swift
+++ b/ViewController.swift
@@ -54,8 +54,8 @@ class ViewController: UIViewController {
         var frame :CGRect = CGRect(origin: self.view.bounds.origin, size: self.view.bounds.size)
         
         //カスタマイズViewを生成
-        let myView = timerView(frame: frame) // '(frame: @lvalue CGRect) -> $T3' is not identical to 'TimerView'
-        
+        let myView = TimerView(frame: frame)
+
         //カスタマイズViewを追加
         self.view.addSubview(myView)
     }


### PR DESCRIPTION
TimerViewクラスに対してそのインスタンスの変数名をtimerViewにするのは悪くないのですが、なれないうちはtimerとか大文字小文字でわかりにくくなるようなものを使わないほうが見やすくなるかもしれません。クラス名にプレフィックスを付けるのも良いかもしれません。
